### PR TITLE
The TavoWeb Analytics tracking script requires a static ID 'ZwSg9rf6G…

### DIFF
--- a/tavoweb-analytics.php
+++ b/tavoweb-analytics.php
@@ -33,7 +33,7 @@ class TavoWeb_Analytics_Plugin {
     public function add_analytics_script() {
         $site_id = get_option('tavoweb_analytics_site_id');
         if (!empty($site_id)) {
-            echo '<script data-host="https://analytics.tavoweb.eu" data-dnt="false" src="https://analytics.tavoweb.eu/js/script.js" id="' . esc_attr($site_id) . '" async defer></script>';
+            echo '<script data-host="https://analytics.tavoweb.eu" data-dnt="false" src="https://analytics.tavoweb.eu/js/script.js" id="ZwSg9rf6GA" async defer></script>';
         }
     }
 


### PR DESCRIPTION
…A' to be present in the script tag.

The previous implementation used the 'site_id' from the plugin settings as the script tag ID, which caused the tracking to fail after the analytics server configuration was changed.

This commit updates the `add_analytics_script` function to use the hardcoded static ID, ensuring that the tracking script is loaded correctly. The 'site_id' setting is still used for fetching stats for the dashboard widget.